### PR TITLE
TestFile: Fix "leak" of temporary files

### DIFF
--- a/CompuMaster.Data.Controls/AssemblyInfo.vb
+++ b/CompuMaster.Data.Controls/AssemblyInfo.vb
@@ -16,7 +16,7 @@ Imports System.Runtime.CompilerServices
 <Assembly: Guid("FDE425FC-D944-4747-A1D8-082356335D53")>
 
 'HINT: ALWAYS UPDATE AT PROJECTS CM.DATA + CM.DATA.CONTROLS TO THE VERY SAME VERSION NO.
-<Assembly: AssemblyVersion("2.8.2017.1221")>
+<Assembly: AssemblyVersion("2.8.2018.0913")>
 '<Assembly: AssemblyInformationalVersion("2.8.2017.1218-beta3")>
 <Assembly: AssemblyDelaySign(False)>
 

--- a/CompuMaster.Data/AssemblyInfo.vb
+++ b/CompuMaster.Data/AssemblyInfo.vb
@@ -16,7 +16,7 @@ Imports System.Runtime.CompilerServices
 <Assembly: Guid("ECE425FC-D944-4747-A1D8-08235073C9B7")>
 
 'HINT: ALWAYS UPDATE AT PROJECTS CM.DATA + CM.DATA.CONTROLS TO THE VERY SAME VERSION NO.
-<Assembly: AssemblyVersion("2.8.2017.1221")>
+<Assembly: AssemblyVersion("2.8.2018.0913")>
 '<Assembly: AssemblyInformationalVersion("2.8.2017.1218-beta3")>
 <Assembly: AssemblyDelaySign(False)>
 

--- a/CompuMaster.Data/DataQuery.TestFile.vb
+++ b/CompuMaster.Data/DataQuery.TestFile.vb
@@ -10,6 +10,7 @@ Namespace CompuMaster.Data.DataQuery
     Friend Class TestFile
         Implements IDisposable
 
+        Private disposed As Boolean
         Private path As String
 
         Public ReadOnly Property FilePath() As String
@@ -26,7 +27,7 @@ Namespace CompuMaster.Data.DataQuery
 
         Public Sub New(ByVal fileType As TestFileType)
             Dim TempFile As String
-            TempFile = System.IO.Path.GetTempFileName
+            TempFile = System.IO.Path.GetTempFileName()
             If fileType = TestFileType.MsExcel95Xls Then
                 CompuMaster.Data.DatabaseManagement.CreateMsExcelFile(TempFile, DatabaseManagement.MsExcelFileType.MsExcel95Xls)
             ElseIf fileType = TestFileType.MsExcel2007Xlsx Then
@@ -39,12 +40,29 @@ Namespace CompuMaster.Data.DataQuery
             path = TempFile
         End Sub
 
-        Public Sub Dispose() Implements System.IDisposable.Dispose
+        Protected Overridable Sub Dispose(disposing As Boolean)
+            If Me.disposed Then
+                Return
+            End If
             Try
-                If System.IO.File.Exists(path) Then System.IO.File.Delete(path)
+                If System.IO.File.Exists(path) Then
+                    System.IO.File.Delete(path)
+                End If
             Catch
             End Try
+            Me.disposed = True
+            Me.path = Nothing
         End Sub
+        Public Sub Dispose() Implements System.IDisposable.Dispose
+            Dispose(True)
+            GC.SuppressFinalize(Me)
+        End Sub
+
+        Protected Overrides Sub Finalize()
+            Dispose(False)
+        End Sub
+
+
 
     End Class
 

--- a/CompuMaster.Test.Tools.Data/AssemblyInfo.vb
+++ b/CompuMaster.Test.Tools.Data/AssemblyInfo.vb
@@ -12,5 +12,5 @@ Imports System.Runtime.InteropServices
 <Assembly: CLSCompliant(True)>
 <Assembly: Guid("D8D4C425-B7A2-4F73-A91B-7C1EA686B0F6")>
 
-<Assembly: AssemblyVersion("2.8.2017.1220")>
+<Assembly: AssemblyVersion("2.8.2018.0913")>
 

--- a/CompuMaster.Test.Tools.Data/DataQuery.TestFile.vb
+++ b/CompuMaster.Test.Tools.Data/DataQuery.TestFile.vb
@@ -1,0 +1,37 @@
+﻿Imports NUnit.Framework
+Imports System.Collections.Generic
+
+Namespace CompuMaster.Test.Data.DataQuery
+
+    <TestFixture(Category:="DataQueryTestFile")> Public Class DataQueryTestFile
+
+        Private Sub CreateAndDispose(ByVal testFileType As CompuMaster.Data.DataQuery.TestFile.TestFileType)
+            Dim testFile As New CompuMaster.Data.DataQuery.TestFile(testFileType)
+            Assert.IsTrue(System.IO.File.Exists(testFile.FilePath), "File exists")
+            Dim filepath As String = testFile.FilePath
+            testFile.Dispose()
+            Assert.IsFalse(System.IO.File.Exists(filepath), "File was deleted")
+
+            Dim cachedPath As String = Nothing
+            Using tsFile As New CompuMaster.Data.DataQuery.TestFile(testFileType)
+                Assert.IsTrue(System.IO.File.Exists(tsFile.FilePath), "File exists")
+                cachedPath = tsFile.FilePath
+            End Using
+            Assert.IsFalse(System.IO.File.Exists(cachedPath), "File was deleted")
+        End Sub
+        <Test> Public Sub CreateAndDisposeMsAccess()
+            CreateAndDispose(CompuMaster.Data.DataQuery.TestFile.TestFileType.MsAccess)
+        End Sub
+
+        <Test> Public Sub CreateAndDisposeMsExcel95Xls()
+            CreateAndDispose(CompuMaster.Data.DataQuery.TestFile.TestFileType.MsExcel95Xls)
+        End Sub
+
+        <Test> Public Sub CreateAndDisposeMsExcel2007Xlsx()
+            CreateAndDispose(CompuMaster.Data.DataQuery.TestFile.TestFileType.MsExcel2007Xlsx)
+        End Sub
+
+
+    End Class
+
+End Namespace


### PR DESCRIPTION
Class TestFile creates temporary files, but does not clean them unless Dispose is called. This can lead to a situation where no more temporary files can be created.

This implements the Dispose pattern (with Finalize). Furthermore, it explicittly calls Dispose on the objects. Also added unit tests for TestFile. 